### PR TITLE
Fixed building grid formation

### DIFF
--- a/scripts/process_data.js
+++ b/scripts/process_data.js
@@ -332,7 +332,7 @@ const processBuildings = (place, rawBuildings) => {
     processedBuildings[i] = {
       bbox: {
         minLon: minBuildingLon,
-        maxLat: minBuildingLat,
+        minLat: minBuildingLat,
         maxLon: maxBuildingLon,
         maxLat: maxBuildingLat,
       },
@@ -343,7 +343,7 @@ const processBuildings = (place, rawBuildings) => {
     }
   });
 
-// === Cell generation logic made more similar to the game ===
+// === Cell size taken from R analysis ===
 const cs  = 0.0009; // latitude (deg)
 const latMid = (minLat + maxLat) / 2;
 const distortionFactor = 1 / Math.cos(latMid * Math.PI / 180);


### PR DESCRIPTION
The game relies on a grid to shorten the computing time for determining if buildings are in the way of under construction tracks. 

In previous versions of this code, the grid was made in a way that caused errors making the intended function super buggy. 

My changes mean that under construction tracks will always collide with buildings