### PR TITLE
Install map tools within "Install dependencies.sh"

### DIFF
--- a/Install dependencies.sh
+++ b/Install dependencies.sh
@@ -28,9 +28,12 @@ cd patcher/packages/mapPatcher || {
 npm install
 npm install adm-zip --save
 
-echo  > Step 3/3: Installing map tools (pmtiles / gzip)...
-cd patcher\packages\mapPatcher
-cd ../../..
+echo " > Step 3/3: Installing map tools (pmtiles / gzip)..."
+node download_tools.js
+cd ../../../ || {
+    echo "ERROR: Could not change directory back to root"
+    exit 1
+}
 
 echo
 echo "========================================================"


### PR DESCRIPTION
The install dependencies script seems to miss the actual installation call for the required map tools. This PR adds the required call and escapes the log string.