### PR TITLE
Version 11.1 mapPatcher Fix

### DIFF
--- a/patcher/packages/mapPatcher/patcherExec.js
+++ b/patcher/packages/mapPatcher/patcherExec.js
@@ -59,7 +59,7 @@ export async function patcherExec(fileContents) {
         existingListOfCitiesRaw += JSON.stringify({
             name: place.name,
             code: place.code,
-            country: place.country || "US", // will place any new map in the US country for now unless otherwise specified, adding a new page for each country can be done
+            country: place.country || "US", // will place any new map in the US country for now unless otherwise specified, adding a new page for each country can be done later
             description: place.description,
             population: place.population,
             initialViewState: place.initialViewState ? place.initialViewState : {


### PR DESCRIPTION
Not sure if this will fix the patcher on its own. I also had to run this command at some point to get the new maps to load: "cd patcher\packages\mapPatcher\map_tiles; .\pmtiles.exe serve . --port 8080". I was also getting 404 errors "Fetch for http://127.0.0.1:8080/PAR/12/2074/1410.mvt failed (attempt 4): HTTP 404. Retrying in 1600ms..." but I couldn't tell if this was related to how I was testing the script. I'll have to investigate further to completely understand the patcher.